### PR TITLE
Added voltage and Cs options to isonet.py deconv

### DIFF
--- a/bin/isonet.py
+++ b/bin/isonet.py
@@ -100,6 +100,8 @@ class ISONET:
 
     def deconv(self, star_file: str,
         deconv_folder:str="./deconv",
+        voltage: float=300.0,
+        cs: float=2.7,
         snrfalloff: float=None,
         deconvstrength: float=None,
         highpassnyquist: float=0.02,
@@ -113,6 +115,8 @@ class ISONET:
         This step is recommanded because it enhances low resolution information for a better contrast. No need to do deconvolution for phase plate data.
         :param deconv_folder: (./deconv) Folder created to save deconvoluted tomograms.
         :param star_file: (None) Star file for tomograms.
+        :param voltage: (300.0) Acceleration voltage in kV.
+        :param cs: (2.7) Spherical aberration in mm.
         :param snrfalloff: (1.0) SNR fall rate with the frequency. High values means losing more high frequency.
         If this value is not set, the program will look for the parameter in the star file.
         If this value is not set and not found in star file, the default value 1.0 will be used.
@@ -156,7 +160,7 @@ class ISONET:
                     base_name = os.path.basename(tomo_file)
                     deconv_tomo_name = '{}/{}'.format(deconv_folder,base_name)
 
-                    deconv_one(it.rlnMicrographName,deconv_tomo_name,defocus=it.rlnDefocus/10000.0, pixel_size=it.rlnPixelSize,snrfalloff=it.rlnSnrFalloff, deconvstrength=it.rlnDeconvStrength,highpassnyquist=highpassnyquist,chunk_size=chunk_size,overlap_rate=overlap_rate,ncpu=ncpu)
+                    deconv_one(it.rlnMicrographName,deconv_tomo_name,voltage=voltage,cs=cs,defocus=it.rlnDefocus/10000.0, pixel_size=it.rlnPixelSize,snrfalloff=it.rlnSnrFalloff, deconvstrength=it.rlnDeconvStrength,highpassnyquist=highpassnyquist,chunk_size=chunk_size,overlap_rate=overlap_rate,ncpu=ncpu)
                     md._setItemValue(it,Label('rlnDeconvTomoName'),deconv_tomo_name)
                 md.write(star_file)
             logging.info('\n######Isonet done ctf deconvolve######\n')

--- a/util/dict2attr.py
+++ b/util/dict2attr.py
@@ -10,7 +10,7 @@ refine_param = [ 'normalize_percentile', 'batch_normalization', 'filter_base', '
                 'select_subtomo_number','remove_intermediate']
 predict_param = ['tomo_idx', 'Ntile', 'log_level', 'normalize_percentile', 'batch_size', 'use_deconv_tomo', 'crop_size', 'cube_size', 'gpuID', 'output_dir', 'model', 'star_file']
 extract_param = ['log_level', 'cube_size', 'subtomo_star', 'subtomo_folder', 'use_deconv_tomo', 'star_file','tomo_idx','crop_size']
-deconv_param = ['star_file', 'deconv_folder','chunk_size', 'snrfalloff', 'deconvstrength', 'highpassnyquist', 'tile', 'overlap_rate', 'ncpu', 'tomo_idx']
+deconv_param = ['star_file', 'deconv_folder','chunk_size', 'snrfalloff', 'deconvstrength', 'highpassnyquist', 'tile', 'overlap_rate', 'ncpu', 'tomo_idx', 'voltage', 'cs']
 make_mask_param = ['star_file', 'mask_folder', 'patch_size', 'density_percentage', 'std_percentage', 'use_deconv_tomo', 'z_crop', 'tomo_idx', 'mask_boundary']
 prepare_star_param = ['number_subtomos', 'defocus', 'pixel_size', 'output_star', 'folder_name']
 prepare_subtomo_star_param = ['folder_name', 'output_star', 'pixel_size', 'cube_size']


### PR DESCRIPTION
I saw that voltage and spherical aberration options were hardcoded, so I added options to provide arbitrary values when working on non-Titan Krios data.