### PR TITLE
Added missing wedge angular range to isonet.py refine

### DIFF
--- a/bin/isonet.py
+++ b/bin/isonet.py
@@ -324,8 +324,10 @@ class ISONET:
         result_dir: str='results',
         remove_intermediate: bool =False,
         select_subtomo_number: int = None,
-        preprocessing_ncpus: int = 16,
         continue_from: str=None,
+        preprocessing_ncpus: int = 16,
+        missingAngle: tuple=(30,30),
+        
         epochs: int = 10,
         batch_size: int = None,
         steps_per_epoch: int = None,
@@ -357,6 +359,10 @@ class ISONET:
         :param continue_from: (None) A Json file to continue from. That json file is generated at each iteration of refine.
         :param result_dir: ('results') The name of directory to save refined neural network models and subtomograms
         :param preprocessing_ncpus: (16) Number of cpu for preprocessing.
+
+        *********************Missing wedge settings*********************
+
+        :param missingAngle: (30,30) Missing wedge angular range in form (left_border, right_border) for the angular range of [-left_border, +right_border] counting from Z axis (default is [-30, +30]).
 
         ************************Training settings************************
 

--- a/preprocessing/prepare.py
+++ b/preprocessing/prepare.py
@@ -148,7 +148,7 @@ def get_cubes(inp,settings):
             offset = center-np.dot(rot,center)
             rotated_data[i] = affine_transform(orig_data,rot,offset=offset)
     
-    mw = mw2d(settings.crop_size)   
+    mw = mw2d(settings.crop_size, settings.missingAngle)   
     datax = apply_wedge_dcube(rotated_data, mw)
 
     for i in range(len(rotation_list)): 

--- a/util/dict2attr.py
+++ b/util/dict2attr.py
@@ -7,7 +7,7 @@ global refine_param, predict_param, extract_param, param_to_check, param_to_set_
 refine_param = [ 'normalize_percentile', 'batch_normalization', 'filter_base', 'unet_depth', 'pool', 'kernel', 'convs_per_depth', 'drop_out','noise_dir', 
                 'noise_mode', 'noise_pause', 'noise_start_iter','learning_rate', 'noise_level', 'steps_per_epoch', 'batch_size', 'epochs', 'continue_from', 
                 'preprocessing_ncpus', 'result_dir', 'continue_iter', 'log_level', 'pretrained_model', 'data_dir', 'iterations', 'gpuID', 'subtomo_star','cmd',
-                'select_subtomo_number','remove_intermediate']
+                'select_subtomo_number','remove_intermediate', 'missingAngle']
 predict_param = ['tomo_idx', 'Ntile', 'log_level', 'normalize_percentile', 'batch_size', 'use_deconv_tomo', 'crop_size', 'cube_size', 'gpuID', 'output_dir', 'model', 'star_file']
 extract_param = ['log_level', 'cube_size', 'subtomo_star', 'subtomo_folder', 'use_deconv_tomo', 'star_file','tomo_idx','crop_size']
 deconv_param = ['star_file', 'deconv_folder','chunk_size', 'snrfalloff', 'deconvstrength', 'highpassnyquist', 'tile', 'overlap_rate', 'ncpu', 'tomo_idx', 'voltage', 'cs']
@@ -27,6 +27,8 @@ class Arg:
             if k == 'noise_start_iter' and type(v) is int:
                 v = tuple([v])
             if k == 'noise_level' and type(v) in [int,float]:
+                v = tuple([v])
+            if k == 'missingAngle' and type(v) is int:
                 v = tuple([v])
             if k in param_to_set_attr:
                 setattr(self, k, v)


### PR DESCRIPTION
Community could benefit even more from IsoNet if there is an option to use custom missing wedge angular range. So I have added parameter to **isonet.py refine** for it.